### PR TITLE
Add functionality to view history of last 100 peps

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,29 @@
+import styles from '../styles/Home.module.css'
+import Link from 'next/link';
+
+type Props = {
+  pageTitle: string;
+  links: {
+    title: string;
+    route: string;
+  }[];
+}
+
+const Header: React.FC<Props> = ({ pageTitle, links }) => {
+  const pageLinks = links.map((link) =>
+    <Link key={link.route} href={link.route}>
+      <a className={styles.link}>{link.title}</a>
+    </Link>
+  );
+
+  return (
+    <header>
+      <h1 className={styles.pageTitle}>{pageTitle}</h1>
+      <div className={styles.pageLinks}>
+        { pageLinks }
+      </div>
+    </header>
+  );
+}
+
+export default Header

--- a/constants/pep.ts
+++ b/constants/pep.ts
@@ -84,3 +84,5 @@ export const fourth = [
     "according to CNN.",
     "so get used to it.",
 ];
+
+export const historyMaxSize = 100;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,16 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 
+function SafeHydrate({ children }: any) {
+  return (
+    <div suppressHydrationWarning>
+      {typeof window === 'undefined' ? null : children}
+    </div>
+  )
+}
+
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return <SafeHydrate><Component {...pageProps} /></SafeHydrate>
 }
 
 export default MyApp

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,0 +1,21 @@
+import { NextPage } from 'next';
+import styles from '../styles/Home.module.css'
+import { PepService } from '../services/pep';
+import Header from '../components/Header';
+
+const History: NextPage = () => {
+  const pageLinks = [ { title: 'Home', route: '/'} ];
+  const peps = PepService.getPepHistory();
+  const listItems = peps.map((pep, index) =>
+    <li key={index.toString()}>{pep}</li>
+  );
+
+  return (
+    <div className={styles.container}>
+      <Header pageTitle={'Pep Talk History'} links={pageLinks} />
+      <ul>{listItems}</ul>
+    </div>
+  );
+}
+
+export default History

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,56 +2,36 @@ import type { NextPage } from 'next'
 import { useState, useEffect } from 'react';
 import Head from 'next/head'
 import styles from '../styles/Home.module.css'
-import { first, second, third, fourth } from '../constants/pep';
+import { PepService } from '../services/pep';
+import { historyMaxSize } from '../constants/pep';
 
 const Home: NextPage = () => {
-  const historyMaxSize = 100;
 
-  const generatePep = (): string => {
-    let pieces = [
-      first[Math.floor(Math.random() * first.length)],
-      second[Math.floor(Math.random() * second.length)],
-      third[Math.floor(Math.random() * third.length)],
-      fourth[Math.floor(Math.random() * fourth.length)],
-    ];
-    
-    return pieces.join(' ');
-  }
-
-  const getPepHistory = (): string[] => {
-    const peps: string | null = localStorage.getItem('pepHistory');
-    return peps ? JSON.parse(peps) : [];
-  }
-
-  const [index, setIndex] = useState(getPepHistory().length);
-  const [phrase, setPhrase] = useState(generatePep());
+  const [index, setIndex] = useState(PepService.getPepHistory().length);
+  const [phrase, setPhrase] = useState(PepService.generatePep());
 
   useEffect(() => {
-    let pepHistory = getPepHistory();
-    if (index >= pepHistory.length) {
-      addPepToHistory(phrase, pepHistory);
+    let history = PepService.getPepHistory();
+    if (index >= history.length) {
+      if (history.length >= historyMaxSize) {
+        history = history.slice(1);
+        setIndex(index - 1);
+      }
+      PepService.addPepToHistory(phrase, history);
     }
   }, [phrase]);
 
-  const addPepToHistory = (pep: string, history: string[]): void => {
-    if (history.length >= historyMaxSize) {
-      history = history.slice(1);
-      setIndex(index - 1);
-    }
-    localStorage.setItem('pepHistory', JSON.stringify([...history, pep]));
-  }
+  const setPep = (): void => {
+    setPhrase(PepService.generatePep());
+    setIndex(PepService.getPepHistory().length);
+  };
 
   const viewHistory = (direction: string = 'back'): void => {
     const pepIndex = direction === 'forward' ? index + 1 : index - 1;
-    const peps = getPepHistory();
+    const peps = PepService.getPepHistory();
     setPhrase(peps[pepIndex]);
     setIndex(pepIndex);
   }
-  
-  const setPep = (): void => {
-    setPhrase(generatePep());
-    setIndex(getPepHistory().length);
-  };
 
   return (
     <div className={styles.container}>
@@ -72,7 +52,7 @@ const Home: NextPage = () => {
           <button className={styles.generate} onClick={setPep}>
             Generate Pep Talk
           </button>
-          <button disabled={index >= getPepHistory().length - 1} className={styles.generate} onClick={() => viewHistory('forward')}>
+          <button disabled={index >= PepService.getPepHistory().length - 1} className={styles.generate} onClick={() => viewHistory('forward')}>
             &#8594;
           </button>
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,15 +1,56 @@
 import type { NextPage } from 'next'
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Head from 'next/head'
 import styles from '../styles/Home.module.css'
-import { PepService } from '../services/pep';
+import { first, second, third, fourth } from '../constants/pep';
 
 const Home: NextPage = () => {
-  
-  const [phrase, setPhrase] = useState(PepService.generatePep());
+  const historyMaxSize = 100;
 
-  const setPep = () => {
-    setPhrase(PepService.generatePep());
+  const generatePep = (): string => {
+    let pieces = [
+      first[Math.floor(Math.random() * first.length)],
+      second[Math.floor(Math.random() * second.length)],
+      third[Math.floor(Math.random() * third.length)],
+      fourth[Math.floor(Math.random() * fourth.length)],
+    ];
+    
+    return pieces.join(' ');
+  }
+
+  const getPepHistory = (): string[] => {
+    const peps: string | null = localStorage.getItem('pepHistory');
+    return peps ? JSON.parse(peps) : [];
+  }
+
+  const [index, setIndex] = useState(getPepHistory().length);
+  const [phrase, setPhrase] = useState(generatePep());
+
+  useEffect(() => {
+    let pepHistory = getPepHistory();
+    if (index >= pepHistory.length) {
+      addPepToHistory(phrase, pepHistory);
+    }
+  }, [phrase]);
+
+  const addPepToHistory = (pep: string, history: string[]): void => {
+    if (history.length >= historyMaxSize) {
+      history = history.slice(1);
+      setIndex(index - 1);
+    }
+    localStorage.setItem('pepHistory', JSON.stringify([...history, pep]));
+  }
+
+  const viewHistory = (direction: string = 'back'): void => {
+    const pepIndex = direction === 'forward' ? index + 1 : index - 1;
+    const peps = getPepHistory();
+    setPhrase(peps[pepIndex]);
+    setIndex(pepIndex);
+  }
+  
+  const setPep = (): void => {
+    setPhrase(generatePep());
+    setIndex(getPepHistory().length);
   };
 
   return (
@@ -25,8 +66,14 @@ const Home: NextPage = () => {
           {phrase}
         </h1>
         <div className={styles.centered}>
+          <button disabled={index === 0} className={styles.generate} onClick={() => viewHistory('back')}>
+            &#8592;
+          </button>
           <button className={styles.generate} onClick={setPep}>
             Generate Pep Talk
+          </button>
+          <button disabled={index >= getPepHistory().length - 1} className={styles.generate} onClick={() => viewHistory('forward')}>
+            &#8594;
           </button>
         </div>
       </main>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,14 @@
 import type { NextPage } from 'next'
 import { useState, useEffect } from 'react';
 import Head from 'next/head'
+import Link from 'next/link'
 import styles from '../styles/Home.module.css'
 import { PepService } from '../services/pep';
 import { historyMaxSize } from '../constants/pep';
+import Header from '../components/Header';
 
 const Home: NextPage = () => {
-
+  const pageLinks = [ { title: 'View History', route: '/history'} ];
   const [index, setIndex] = useState(PepService.getPepHistory().length);
   const [phrase, setPhrase] = useState(PepService.generatePep());
 
@@ -40,6 +42,8 @@ const Home: NextPage = () => {
         <meta name="description" content="Give someone a pep talk" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
+
+      <Header pageTitle={'Pep Talk Generator'} links={pageLinks} />
 
       <main className={styles.main}>
         <h1 className={styles.title}>

--- a/services/pep.ts
+++ b/services/pep.ts
@@ -1,14 +1,23 @@
 import { first, second, third, fourth } from '../constants/pep';
 
 export class PepService {
-    static generatePep() {
-        let pieces = [
-            first[Math.floor(Math.random() * first.length)],
-            second[Math.floor(Math.random() * second.length)],
-            third[Math.floor(Math.random() * third.length)],
-            fourth[Math.floor(Math.random() * fourth.length)],
-        ];
-    
-        return pieces.join(' ');
-    }
+  static generatePep() {
+    let pieces = [
+      first[Math.floor(Math.random() * first.length)],
+      second[Math.floor(Math.random() * second.length)],
+      third[Math.floor(Math.random() * third.length)],
+      fourth[Math.floor(Math.random() * fourth.length)],
+    ];
+
+    return pieces.join(' ');
+  }
+
+  static getPepHistory(): string[] {
+    const peps: string | null = localStorage.getItem('pepHistory');
+    return peps ? JSON.parse(peps) : [];
+  }
+
+  static addPepToHistory(pep: string, history: string[]): void {
+    localStorage.setItem('pepHistory', JSON.stringify([...history, pep]));
+  }
 }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -131,6 +131,17 @@
   margin-left: 0.5rem;
 }
 
+.pageTitle {
+  padding: 0;
+  margin: 0;
+}
+
+.pageLinks {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
 @media (max-width: 600px) {
   .grid {
     width: 100%;

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -3,7 +3,9 @@
 }
 
 .centered {
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
   margin-top: 5em;
 }
 

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -26,7 +26,7 @@
 }
 
 .main {
-  min-height: 100vh;
+  min-height: calc(100vh - 70px); /* 100vh minus header height */
   padding: 4rem 0;
   flex: 1;
   display: flex;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,9 +6,15 @@ body {
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+}
+
 a {
-  color: inherit;
-  text-decoration: none;
+  font-size: 1.5rem;
 }
 
 * {
@@ -22,4 +28,8 @@ button[disabled]{
   background: #cccccc;
   color: #666666;
   cursor: not-allowed;
+}
+
+li {
+  margin: 1rem 0;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,3 +14,12 @@ a {
 * {
   box-sizing: border-box;
 }
+
+button:disabled,
+button[disabled]{
+  border: 1px solid #999999;
+  box-shadow: none;
+  background: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
This PR adds functionality for viewing the last 100 pep talks generated by the user. The user can navigate forward and backward through the pep history. The peps are stored in the user's browser local storage to maintain state on browser reloads. Note that I also added the SafeHydrate wrapper to _app.tsx due to the inability to access local storage when pre-rendering component server-side.